### PR TITLE
Change date of alembic script, code style fixes

### DIFF
--- a/KerbalStuff/search.py
+++ b/KerbalStuff/search.py
@@ -53,6 +53,7 @@ def versions_behind(mod: Mod) -> int:
     except version.InvalidVersion:
         return 0
 
+
 def game_versions(game: Game) -> Iterable[version.Version]:
     for gv in game.versions:
         try:
@@ -60,6 +61,7 @@ def game_versions(game: Game) -> Iterable[version.Version]:
             yield ver
         except version.InvalidVersion:
             pass
+
 
 def search_mods(ga: Optional[Game], text: str, page: int, limit: int) -> Tuple[List[Mod], int]:
     terms = text.split(' ')

--- a/alembic/versions/2020_07_11_17_30_00-1aa078e0fb7e.py
+++ b/alembic/versions/2020_07_11_17_30_00-1aa078e0fb7e.py
@@ -2,7 +2,7 @@
 
 Revision ID: 1aa078e0fb7e
 Revises: 544564b4e738
-Create Date: 2020-06-26 01:24:00
+Create Date: 2020-07-11 17:30:00
 
 """
 

--- a/templates/view_profile.html
+++ b/templates/view_profile.html
@@ -121,35 +121,38 @@
                 <div class="col-md-6">
                     {{ profile.description | markdown }}
                     {% if user.admin %}
-                    <p>
-                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Email:</span> <a href="mailto:{{ profile.email }}">{{ profile.email }}</a>
-                    <br />
-                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Confirmed:</span> {% if profile.confirmation == None -%}
-                        Yes
-                    {%- else -%}
-                        No
-                        <a href="/admin/manual-confirmation/{{ profile.id }}">[Confirm Manually]</a>
-                    {%- endif -%}
-                    <br />
-                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Public:</span> {% if profile.public -%}
-                        Yes
-                    {%- else -%}
-                        No
-                    {%- endif -%}
-                    <br />
-                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Created:</span> {{ profile.created }}
-                    <br />
-                    <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Admin:</span> {% if profile.admin -%}
-                        Yes
-                    {%- else -%}
-                        No
-                        <a data-toggle="modal" href="#confirm-grant-admin">[Grant Admin]</a>
-                    {%- endif -%}
-                    </p>
-                    <a href="/admin/impersonate/{{profile.username}}" class="btn btn-primary" style="margin-bottom: 10px; margin-top: 5px;">
-                        <span class="glyphicon glyphicon-fire"></span>
-                        Impersonate user
-                    </a>
+                        <p>
+                        <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Email: </span><a href="mailto:{{ profile.email }}">{{ profile.email }}</a>
+                        <br />
+                        <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Confirmed: </span>
+                        {%- if profile.confirmation == None -%}
+                            Yes
+                        {%- else -%}
+                            No
+                            <a href="/admin/manual-confirmation/{{ profile.id }}">[Confirm Manually]</a>
+                        {%- endif -%}
+                        <br />
+                        <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Public: </span>
+                        {%- if profile.public -%}
+                            Yes
+                        {%- else -%}
+                            No
+                        {%- endif -%}
+                        <br />
+                        <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Created: </span>{{ profile.created }}
+                        <br />
+                        <span class="glyphicon glyphicon-fire" /> <span class="text-muted">Admin: </span>
+                        {%- if profile.admin -%}
+                            Yes
+                        {%- else -%}
+                            No
+                            <a data-toggle="modal" href="#confirm-grant-admin">[Grant Admin]</a>
+                        {%- endif -%}
+                        </p>
+                        <a href="/admin/impersonate/{{profile.username}}" class="btn btn-primary" style="margin-bottom: 10px; margin-top: 5px;">
+                            <span class="glyphicon glyphicon-fire"></span>
+                            Impersonate user
+                        </a>
                     {% endif %}
                 </div>
             </div>


### PR DESCRIPTION
I changed the date of the alembic script to today so it sorts in the revision order in file browsers, helps organizing them. I'm thinking about changing the naming scheme of them alltogether, it's not like we create so many migration scripts that we need the time down to the second ^^
But I have yet to think of something better and easy.

The new `def game_versions()` only has one empty line above and below, my IDE complains about it...

I also pulled the `if`s in the admin-only-visible part of `view_profile.html` into new lines, since they have been hidden outside my screen, which made the if statements code very confusing to look at and hard to untangle.
Additionally I've indented all the lines inside `{% if user.admin %}...{% endif %}` to make it even clearer.