### PR TITLE
Make blog.members_only and blog.announcement non-nullable

### DIFF
--- a/KerbalStuff/app.py
+++ b/KerbalStuff/app.py
@@ -317,5 +317,5 @@ def get_all_announcement_posts() -> List[BlogPost]:
 
 def get_non_member_announcement_posts() -> List[BlogPost]:
     return BlogPost.query.filter(
-        BlogPost.announcement, BlogPost.members_only.isnot(True)
+        BlogPost.announcement, BlogPost.members_only != True
     ).order_by(desc(BlogPost.created)).all()

--- a/KerbalStuff/blueprints/blog.py
+++ b/KerbalStuff/blueprints/blog.py
@@ -14,7 +14,7 @@ blog = Blueprint('blog', __name__, template_folder='../../templates/blog')
 def index() -> str:
     posts = (BlogPost.query.order_by(BlogPost.created.desc()).all()
              if current_user
-             else BlogPost.query.filter(BlogPost.members_only.isnot(True)).order_by(BlogPost.created.desc()).all())
+             else BlogPost.query.filter(BlogPost.members_only != True).order_by(BlogPost.created.desc()).all())
     return render_template("blog_index.html", posts=posts)
 
 

--- a/KerbalStuff/objects.py
+++ b/KerbalStuff/objects.py
@@ -32,8 +32,8 @@ class BlogPost(Base):  # type: ignore
     id = Column(Integer, primary_key=True)
     title = Column(Unicode(1024))
     text = Column(Unicode(65535))
-    announcement = Column(Boolean(), index=True, nullable=True, default=False)
-    members_only = Column(Boolean(), index=True, nullable=True, default=False)
+    announcement = Column(Boolean(), index=True, nullable=False, default=False)
+    members_only = Column(Boolean(), index=True, nullable=False, default=False)
     created = Column(DateTime, default=datetime.now, index=True)
 
     def __repr__(self) -> str:

--- a/alembic/versions/2021_05_10_12_00_00-426e0b848d77.py
+++ b/alembic/versions/2021_05_10_12_00_00-426e0b848d77.py
@@ -15,10 +15,19 @@ import sqlalchemy as sa
 
 
 def upgrade() -> None:
+    # First create nullable column
     op.add_column('blog', sa.Column('members_only', sa.Boolean(), nullable=True, default=False))
+    # Set existing rows to False, using raw SQL for simplicity
+    op.execute("UPDATE blog SET members_only = false")
+    # Set NULL announcement rows to false as well
+    op.execute("UPDATE blog SET announcement = false WHERE announcement is NULL")
+    # Make columns non-nullable
+    op.alter_column('blog', 'members_only', nullable=False)
+    op.alter_column('blog', 'announcement', nullable=False)
     op.create_index(op.f('ix_blog_members_only'), 'blog', ['members_only'], unique=False)
 
 
 def downgrade() -> None:
     op.drop_index(op.f('ix_blog_members_only'), table_name='blog')
     op.drop_column('blog', 'members_only')
+    op.alter_column('blog', 'announcement', nullable=True)

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -27,21 +27,10 @@ class op:
                    column: sa.Column) -> None: ...
 
     @classmethod
-    def drop_column(cls,
+    def alter_column(cls,
                     table_name: str,
-                    column: str) -> None: ...
-
-    @classmethod
-    def create_index(cls,
-                     index_name: str,
-                     table_name: str,
-                     columns: List[str],
-                     unique: Optional[bool] = False) -> None: ...
-
-    @classmethod
-    def drop_index(cls,
-                   index_name: str,
-                   table_name: Optional[str] = None) -> None: ...
+                    column_name: str,
+                    nullable: Optional[bool] = None) -> None: ...
 
     @classmethod
     def create_foreign_key(cls,
@@ -50,9 +39,30 @@ class op:
                            referent_table: str,
                            local_cols: List[str],
                            remote_cols: List[str]) -> None: ...
+    @classmethod
+    def create_index(cls,
+                     index_name: str,
+                     table_name: str,
+                     columns: List[str],
+                     unique: Optional[bool] = False) -> None: ...
+
+
+    @classmethod
+    def drop_column(cls,
+                    table_name: str,
+                    column: str) -> None: ...
 
     @classmethod
     def drop_constraint(cls,
                         constraint_name: str,
                         table_name: str,
                         type_: Optional[str] = None) -> None: ...
+
+    @classmethod
+    def drop_index(cls,
+                   index_name: str,
+                   table_name: Optional[str] = None) -> None: ...
+
+    @classmethod
+    def execute(cls,
+                sqltext: str) -> None: ...


### PR DESCRIPTION
## Motivation
IMHO keeping columns (especially boolean ones) that don't need to be nullable as non-nullable is preferable.
It can prevent some unexpected surprises, and specialties like the `.isnot()`.

It needs two extra steps in the migration, but I think that's better than dragging along the technical dept.

## Changes
The columns/properties `blog.members_only` and `blog.announcemen` in the ORM declarations are now marked as `nullable=False`.
The `.isnot(True)` are replaced with ` != True`.

The migration script firs creates `members_only` as nullable column, then it set every row to `false` (there can't be any with `true` yet).
For the `announcement` column we only `SET announcement = false WHERE announcement is NULL` (ha, you can drop an SQL query in a sentence and it is almost still valid English).
Both are done as raw SQL query since it's simple enough and to avoid having to copy over the class declarations.
Afterwards we change both columns to set their nullable property to `false`.

The mypy type mock-up is expanded as needed, and I also reordered the methods alphabetically.