### PR TITLE
Fix database migration and relationships

### DIFF
--- a/KerbalStuff/email.py
+++ b/KerbalStuff/email.py
@@ -102,7 +102,7 @@ def send_update_notification(mod: Mod, version: ModVersion, user: User) -> None:
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
             'changelog': changelog
         }))
-    subject = user.username + " has just updated " + mod.name + "!"
+    subject = f'{user.username} has just updated {mod.name}!'
     send_mail.delay(_cfg('support-mail'), targets, subject, message)
 
 
@@ -127,8 +127,7 @@ def send_autoupdate_notification(mod: Mod) -> None:
             'url': '/mod/' + str(mod.id) + '/' + secure_filename(mod.name)[:64],
             'changelog': changelog
         }))
-    subject = mod.name + " is compatible with " + \
-              mod.game.name + mod.versions[0].gameversion.friendly_version + "!"
+    subject = f'{mod.name} is compatible with {mod.game.name} {mod.versions[0].gameversion.friendly_version}!'
     send_mail.delay(_cfg('support-mail'), targets, subject, message)
 
 

--- a/alembic/versions/alembic.pyi
+++ b/alembic/versions/alembic.pyi
@@ -9,13 +9,15 @@
 """
 
 from typing import List, Optional
-from sqlalchemy import sa
+
+import sqlalchemy.sql.type_api
+import sqlalchemy as sa
 
 
 class op:
 
     @classmethod
-    def get_bind(cls) -> None: ...
+    def get_bind(cls) -> sa.engine.Connection: ...
 
     @classmethod
     def f(cls,
@@ -35,6 +37,7 @@ class op:
     def alter_column(cls,
                     table_name: str,
                     column_name: str,
+                    existing_type: Optional[sa.sql.type_api.TypeEngine] = None,
                     nullable: Optional[bool] = None) -> None: ...
 
     @classmethod
@@ -58,6 +61,12 @@ class op:
                            remote_cols: List[str],
                            onupdate: Optional[str] = None,
                            ondelete: Optional[str] = None) -> None: ...
+
+    @classmethod
+    def create_primary_key(cls,
+                           constraint_name: str,
+                           table_name: str,
+                           columns: List[str]) -> None: ...
 
     @classmethod
     def drop_constraint(cls,


### PR DESCRIPTION
For https://github.com/KSP-SpaceDock/SpaceDock/pull/369

The migration doesn't match the code in `objects.py`, as you can see if you run `./generate_revision.sh` – it creates a new revision that undos most of the operations of the existing revision:

```python
def upgrade() -> None:
    # ### commands auto generated by Alembic - please adjust! ###
    op.alter_column('mod_followers', 'mod_id',
               existing_type=sa.INTEGER(),
               nullable=False)
    op.alter_column('mod_followers', 'user_id',
               existing_type=sa.INTEGER(),
               nullable=False)
    op.drop_index('ix_mod_followers_mod_id', table_name='mod_followers')
    op.drop_index('ix_mod_followers_user_id', table_name='mod_followers')
    op.drop_index('ix_mod_followers_user_id_mod_id', table_name='mod_followers')
    # ### end Alembic commands ###
```

This PR adjusts both the code in `objects.py` and the revision script to match:
- Mark `Following.mod_id` and `Following.user_id` with `index=True`
- Create a proper primary key for `Following`, instead of a simple index.
- For the above, the two columns of the pkey need to be nonnullable, which the migration does now as well
- For the above, we need to ensure no row has any nulls in those two columns before altering the table, otherwise it fails. We simply delete those rows, they're invalid anyway.

Additionally:
- Mark the `send_update` and `send_autoupdate` columns nonnullable. They're boolean columns which should always be either true or false.

Then there were always the following warnings when running the migrations:
```
INFO  [alembic.runtime.migration] Running upgrade 426e0b848d77 -> 17fbd4ff8193, Add indexes and new columns to mod_followers

/usr/local/bin/spacedock:89: SAWarning: relationship 'Mod.followers' will copy column mod.id to column mod_followers.mod_id, which conflicts with relationship(s): 'Following.mod' (copies mod.id to mod_followers.mod_id).
If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only.
For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   
To silence this warning, add the parameter 'overlaps="mod"' to the 'Mod.followers' relationship.

  if not User.query.filter(User.username.ilike("admin")).first():
  
/usr/local/bin/spacedock:89: SAWarning: relationship 'Mod.followers' will copy column user.id to column mod_followers.user_id, which conflicts with relationship(s): 'Following.user' (copies user.id to mod_followers.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="user"' to the 'Mod.followers' relationship.
  if not User.query.filter(User.username.ilike("admin")).first():
/usr/local/bin/spacedock:89: SAWarning: relationship 'User.following' will copy column user.id to column mod_followers.user_id, which conflicts with relationship(s): 'Following.user' (copies user.id to mod_followers.user_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="user"' to the 'User.following' relationship.
  if not User.query.filter(User.username.ilike("admin")).first():
/usr/local/bin/spacedock:89: SAWarning: relationship 'User.following' will copy column mod.id to column mod_followers.mod_id, which conflicts with relationship(s): 'Following.mod' (copies mod.id to mod_followers.mod_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="mod"' to the 'User.following' relationship.
  if not User.query.filter(User.username.ilike("admin")).first():
```

SQLAlchemy gets confused by the association table having relationships itself, to the same columns of the two rows.
I think I managed to remodel the relations in a way SQLAlchemy understands them while not breaking any of the existing code that accesses these relationships, following these guides:
- https://docs.sqlalchemy.org/en/14/orm/basic_relationships.html?highlight=back_populates#association-object
- https://docs.sqlalchemy.org/en/14/orm/extensions/associationproxy.html#simplifying-association-objects
(be prepared to read the pages half a dozen times before even beginning to understand how it works, took me ages)

Some of the code could be modified to take advantage of the new `.followings` attributes I think, but I didn't do that for now, to not increase the complexity of the changes of this PR even more.
I'm also not happy about the naming similarity of `User.followings` and `User.following`, maybe we could rename `following` to `follows`.